### PR TITLE
Fix int not iterable error on make_env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
 *.egg-info/
-
+*.pyc

--- a/multiagent/environment.py
+++ b/multiagent/environment.py
@@ -65,7 +65,7 @@ class MultiAgentEnv(gym.Env):
                 self.action_space.append(total_action_space[0])
             # observation space
             obs_dim = len(observation_callback(agent, self.world))
-            self.observation_space.append(spaces.Box(low=-np.inf, high=+np.inf, shape=(obs_dim),))
+            self.observation_space.append(spaces.Box(low=-np.inf, high=+np.inf, shape=(obs_dim,)))
             agent.action.c = np.zeros(self.world.dim_c)
 
         # rendering


### PR DESCRIPTION
From the `gym` code, it seems like `spaces.Box` expects an argument `shape` which is iterable. At current master, the following code fails: 

```python
>>> from make_env import make_env
>>> make_env("simple")
WARN: gym.spaces.Box autodetected dtype as <type 'numpy.float32'>. Please provide explicit dtype.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "make_env.py", line 43, in make_env
    env = MultiAgentEnv(world, scenario.reset_world, scenario.reward, scenario.observation)
  File "multiagent/environment.py", line 68, in __init__
    self.observation_space.append(spaces.Box(low=-np.inf, high=+np.inf, shape=(obs_dim),))
  File "/home/anand/dev/openai-venv/local/lib/python2.7/site-packages/gym/spaces/box.py", line 34, in __init__
    gym.Space.__init__(self, shape, dtype)
  File "/home/anand/dev/openai-venv/local/lib/python2.7/site-packages/gym/core.py", line 181, in __init__
    self.shape = None if shape is None else tuple(shape)
TypeError: 'int' object is not iterable
>>> 
```
It's not clear from the code in `environment.py` exactly what the intended shape is, but it looks like a misplaced comma. With the proposed change the code works. 

I also added `.pyc` to the gitignore to avoid committing those files.
